### PR TITLE
add TypedArray to builtin list

### DIFF
--- a/globals-docs.json
+++ b/globals-docs.json
@@ -46,6 +46,7 @@
     "System": "https://developer.mozilla.org/en-US/docs/Web/API/File_System_API",
     "toLocaleString": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleString",
     "toString": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/toString",
+    "TypedArray": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray",
     "TypeError": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError",
     "Uint16Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint16Array",
     "Uint32Array": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint32Array",


### PR DESCRIPTION
TypedArray is not exactly an available global property or constructor
but it is used to talk about typed array constructors in general.
It is documented as a global in MDN and it would be useful to have it
linked when an API accepts any typed array argument.